### PR TITLE
修复TimePicker滚动改变数据时onChange的回调中只有当前列数据改变

### DIFF
--- a/src/components/Timepicker/index.tsx
+++ b/src/components/Timepicker/index.tsx
@@ -126,6 +126,10 @@ export class Timepicker extends React.Component<TimepickerProps, any> {
     const ret = tmpValue.map((valueItem, valueIndex) => {
       return list[valueIndex][valueItem].value
     })
+  this.setState({
+       ...this.state,
+       value: ret,
+     })
     this.props.onChange && this.props.onChange(ret.join(':'))
   }
 


### PR DESCRIPTION
修复TimePicker滚动改变数据时onChange的回调中只有当前列数据改变了，之前滚动的值没有记录